### PR TITLE
chore(github-action): manual screenshot update workflow

### DIFF
--- a/.github/workflows/update-failed-screenshots.yml
+++ b/.github/workflows/update-failed-screenshots.yml
@@ -1,0 +1,37 @@
+name: Update Screenshots
+
+on: workflow_dispatch
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install playwright browsers
+        run: npx playwright install --with-deps
+
+      - name: Run tests
+        run: npm run test
+
+      - name: Update screenshots
+        if: failure()
+        run: npm run test:update
+
+      - name: Upload failed screenshots as artifacts
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: failed_screenshots
+          path: |
+            screenshots/*/failed/
+            screenshots/*/baseline/


### PR DESCRIPTION
This github action allows creating screenshots in the CI on a manual trigger.