### PR TITLE
fix(open-scd): import locales from relative URL

### DIFF
--- a/open-scd.ts
+++ b/open-scd.ts
@@ -37,7 +37,8 @@ type LocaleTag = typeof allLocales[number];
 const { getLocale, setLocale } = configureLocalization({
   sourceLocale,
   targetLocales,
-  loadLocale: locale => import(`./locales/${locale}.js`),
+  loadLocale: locale =>
+    import(new URL(`locales/${locale}.js`, import.meta.url).href),
 });
 
 function describe({ undo, redo }: LogEntry) {


### PR DESCRIPTION
Imports locales from the right place when a bundled version of `open-scd-core` is being loaded from a remote host.