### PR TITLE
fix(open-scd): hide menu plugin element container

### DIFF
--- a/open-scd.ts
+++ b/open-scd.ts
@@ -315,6 +315,17 @@ export class OpenSCD extends Plugging(Editing(LitElement)) {
   }
 
   static styles = css`
+    aside {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 0;
+      height: 0;
+      overflow: hidden;
+      margin: 0;
+      padding: 0;
+    }
+
     abbr {
       text-decoration: none;
     }


### PR DESCRIPTION
Fixes #77 .