### PR TITLE
fix(plugging): import relative paths from origin

### DIFF
--- a/mixins/Plugging.ts
+++ b/mixins/Plugging.ts
@@ -44,9 +44,8 @@ export function Plugging<TBase extends LitElementConstructor>(Base: TBase) {
           if (this.loadedPlugins.has(tagName)) return;
           this.#loadedPlugins.set(tagName, plugin);
           if (customElements.get(tagName)) return;
-          import(plugin.src).then(mod =>
-            customElements.define(tagName, mod.default)
-          );
+          const url = new URL(plugin.src, window.location.href).toString();
+          import(url).then(mod => customElements.define(tagName, mod.default));
         })
       );
 


### PR DESCRIPTION
Resolve `src` URLs for plugins relative to `window.location.host` to make the editor work as expected when a bundled `open-scd.js` is imported from a remote host.