### PR TITLE
feat(foundation): export cyrb64 hash function

### DIFF
--- a/foundation.ts
+++ b/foundation.ts
@@ -23,3 +23,5 @@ export type {
   Update,
   Remove,
 } from './foundation/edit-event.js';
+
+export { cyrb64 } from './foundation/cyrb64.js';

--- a/foundation/cyrb64.ts
+++ b/foundation/cyrb64.ts
@@ -1,0 +1,27 @@
+/**
+ * Hashes `str` using the cyrb64 variant of
+ * https://github.com/bryc/code/blob/master/jshash/experimental/cyrb53.js
+ * @returns digest - a rather insecure hash, very quickly
+ */
+export function cyrb64(str: string): string {
+  /* eslint-disable no-bitwise */
+  let h1 = 0xdeadbeef;
+  let h2 = 0x41c6ce57;
+  /* eslint-disable-next-line no-plusplus */
+  for (let i = 0, ch; i < str.length; i++) {
+    ch = str.charCodeAt(i);
+    h1 = Math.imul(h1 ^ ch, 2654435761);
+    h2 = Math.imul(h2 ^ ch, 1597334677);
+  }
+  h1 =
+    Math.imul(h1 ^ (h1 >>> 16), 2246822507) ^
+    Math.imul(h2 ^ (h2 >>> 13), 3266489909);
+  h2 =
+    Math.imul(h2 ^ (h2 >>> 16), 2246822507) ^
+    Math.imul(h1 ^ (h1 >>> 13), 3266489909);
+  return (
+    (h2 >>> 0).toString(16).padStart(8, '0') +
+    (h1 >>> 0).toString(16).padStart(8, '0')
+  );
+  /* eslint-enable no-bitwise */
+}

--- a/mixins/Plugging.ts
+++ b/mixins/Plugging.ts
@@ -1,6 +1,6 @@
 import { property, state } from 'lit/decorators.js';
 
-import { LitElementConstructor } from '../foundation.js';
+import { cyrb64, LitElementConstructor } from '../foundation.js';
 import { targetLocales } from '../locales.js';
 
 export type Plugin = {
@@ -14,37 +14,10 @@ export type Plugin = {
 export type PluginSet = { menu: Plugin[]; editor: Plugin[] };
 
 const pluginTags = new Map<string, string>();
-/**
- * Hashes `uri` using cyrb64 analogous to
- * https://github.com/bryc/code/blob/master/jshash/experimental/cyrb53.js .
- * @returns a valid customElement tagName containing the URI hash.
- */
+
+/** @returns a valid customElement tagName containing the URI hash. */
 export function pluginTag(uri: string): string {
-  if (!pluginTags.has(uri)) {
-    /* eslint-disable no-bitwise */
-    let h1 = 0xdeadbeef;
-    let h2 = 0x41c6ce57;
-    /* eslint-disable-next-line no-plusplus */
-    for (let i = 0, ch; i < uri.length; i++) {
-      ch = uri.charCodeAt(i);
-      h1 = Math.imul(h1 ^ ch, 2654435761);
-      h2 = Math.imul(h2 ^ ch, 1597334677);
-    }
-    h1 =
-      Math.imul(h1 ^ (h1 >>> 16), 2246822507) ^
-      Math.imul(h2 ^ (h2 >>> 13), 3266489909);
-    h2 =
-      Math.imul(h2 ^ (h2 >>> 16), 2246822507) ^
-      Math.imul(h1 ^ (h1 >>> 13), 3266489909);
-    pluginTags.set(
-      uri,
-      `oscd-p${
-        (h2 >>> 0).toString(16).padStart(8, '0') +
-        (h1 >>> 0).toString(16).padStart(8, '0')
-      }`
-    );
-    /* eslint-enable no-bitwise */
-  }
+  if (!pluginTags.has(uri)) pluginTags.set(uri, `oscd-p${cyrb64(uri)}`);
   return pluginTags.get(uri)!;
 }
 


### PR DESCRIPTION
This exports a 64bit version of the very quick [`cyrb53` hash function by bryc](https://github.com/bryc/code/blob/master/jshash/experimental/cyrb53.js) from our foundation library for plugin authors to use. Thank you @bryc !