### PR TITLE
feat(open-scd): pass editCount to editor and menu plugins

### DIFF
--- a/mixins/Editing.ts
+++ b/mixins/Editing.ts
@@ -122,11 +122,11 @@ export function Editing<TBase extends LitElementConstructor>(Base: TBase) {
     protected history: LogEntry[] = [];
 
     @state()
-    protected next: number = 0;
+    protected editCount: number = 0;
 
     @state()
     protected get last(): number {
-      return this.next - 1;
+      return this.editCount - 1;
     }
 
     @state()
@@ -136,7 +136,7 @@ export function Editing<TBase extends LitElementConstructor>(Base: TBase) {
 
     @state()
     protected get canRedo(): boolean {
-      return this.next < this.history.length;
+      return this.editCount < this.history.length;
     }
 
     /** The set of `XMLDocument`s currently loaded */
@@ -153,24 +153,24 @@ export function Editing<TBase extends LitElementConstructor>(Base: TBase) {
 
     protected handleEditEvent(event: EditEvent) {
       const edit = event.detail;
-      this.history.splice(this.next);
+      this.history.splice(this.editCount);
       this.history.push({ undo: handleEdit(edit), redo: edit });
-      this.next += 1;
+      this.editCount += 1;
     }
 
     /** Undo the last `n` [[Edit]]s committed */
     undo(n = 1) {
       if (!this.canUndo || n < 1) return;
       handleEdit(this.history[this.last!].undo);
-      this.next -= 1;
+      this.editCount -= 1;
       if (n > 1) this.undo(n - 1);
     }
 
     /** Redo the last `n` [[Edit]]s that have been undone */
     redo(n = 1) {
       if (!this.canRedo || n < 1) return;
-      handleEdit(this.history[this.next].redo);
-      this.next += 1;
+      handleEdit(this.history[this.editCount].redo);
+      this.editCount += 1;
       if (n > 1) this.redo(n - 1);
     }
 

--- a/open-scd.spec.ts
+++ b/open-scd.spec.ts
@@ -1,0 +1,152 @@
+import { expect } from '@open-wc/testing';
+
+import './open-scd.js';
+import type { OpenSCD } from './open-scd.js';
+
+import { newEditEvent, newOpenEvent } from './foundation.js';
+
+function isOscdPlugin(tag: string): boolean {
+  return tag.toLocaleLowerCase().startsWith('oscd-p');
+}
+
+const doc = new DOMParser().parseFromString(
+  `<testdoc></testdoc>`,
+  'application/xml'
+);
+
+let editor: OpenSCD;
+beforeEach(() => {
+  editor = document.createElement('open-scd');
+  document.body.prepend(editor);
+});
+
+afterEach(() => {
+  editor.remove();
+});
+
+describe('with editor plugins loaded', () => {
+  beforeEach(async () => {
+    editor.plugins = {
+      menu: [],
+      editor: [
+        {
+          name: 'Test Editor Plugin',
+          translations: { de: 'Test Editor Erweiterung' },
+          src: 'data:text/javascript;charset=utf-8,export%20default%20class%20TestEditorPlugin%20extends%20HTMLElement%20%7B%0D%0A%20%20constructor%20%28%29%20%7B%20super%28%29%3B%20this.innerHTML%20%3D%20%60%3Cp%3ETest%20Editor%20Plugin%3C%2Fp%3E%60%3B%20%7D%0D%0A%7D',
+          icon: 'edit',
+          active: true,
+          requireDoc: false,
+        },
+      ],
+    };
+    await editor.updateComplete;
+  });
+
+  it('passes attribute locale', () => {
+    const plugin = editor.shadowRoot?.querySelector('*[locale="en"]');
+    expect(plugin?.tagName).to.exist.and.to.satisfy(isOscdPlugin);
+  });
+
+  it('passes attribute docname', async () => {
+    editor.dispatchEvent(newOpenEvent(doc, 'test.xml'));
+    await editor.updateComplete;
+
+    const plugin = editor.shadowRoot?.querySelector('*[docName="test.xml"]');
+    expect(plugin?.tagName).to.exist.and.to.satisfy(isOscdPlugin);
+  });
+
+  it('passes property doc', async () => {
+    editor.dispatchEvent(newOpenEvent(doc, 'test.xml'));
+    await editor.updateComplete;
+
+    const plugin = editor.shadowRoot?.querySelector('*[docname="test.xml"]');
+    expect(plugin).to.have.property('docs');
+  });
+
+  it('passes property editCount', async () => {
+    editor.dispatchEvent(newOpenEvent(doc, 'test.xml'));
+    await editor.updateComplete;
+
+    const plugin = editor.shadowRoot?.querySelector('*[docname="test.xml"]');
+    expect(plugin).to.have.property('editCount', 0);
+  });
+
+  it('updated passed editCount property on edit events', async () => {
+    editor.dispatchEvent(newOpenEvent(doc, 'test.xml'));
+    await editor.updateComplete;
+
+    editor.dispatchEvent(
+      newEditEvent({
+        element: doc.querySelector('testdoc')!,
+        attributes: { name: 'someName' },
+      })
+    );
+    await editor.updateComplete;
+
+    const plugin = editor.shadowRoot?.querySelector('*[docname="test.xml"]');
+    expect(plugin).to.have.property('editCount', 1);
+  });
+});
+
+describe('with menu plugins loaded', () => {
+  beforeEach(async () => {
+    editor.plugins = {
+      menu: [
+        {
+          name: 'Test Menu Plugin',
+          translations: { de: 'Test Menü Erweiterung' },
+          src: 'data:text/javascript;charset=utf-8,export%20default%20class%20TestPlugin%20extends%20HTMLElement%20%7B%0D%0A%20%20async%20run%28%29%20%7B%0D%0A%20%20%20%20return%20false%3B%0D%0A%20%20%7D%0D%0A%7D',
+          icon: 'android',
+          active: true,
+          requireDoc: true,
+        },
+      ],
+    };
+    await editor.updateComplete;
+  });
+
+  it('passes attribute locale', () => {
+    const plugin = editor.shadowRoot?.querySelector('*[locale="en"]');
+    expect(plugin?.tagName).to.exist.and.to.satisfy(isOscdPlugin);
+  });
+
+  it('passes attribute docname', async () => {
+    editor.dispatchEvent(newOpenEvent(doc, 'test.xml'));
+    await editor.updateComplete;
+
+    const plugin = editor.shadowRoot?.querySelector('*[docName="test.xml"]');
+    expect(plugin?.tagName).to.exist.and.to.satisfy(isOscdPlugin);
+  });
+
+  it('passes property doc', async () => {
+    editor.dispatchEvent(newOpenEvent(doc, 'test.xml'));
+    await editor.updateComplete;
+
+    const plugin = editor.shadowRoot?.querySelector('*[docname="test.xml"]');
+    expect(plugin).to.have.property('docs');
+  });
+
+  it('passes property editCount', async () => {
+    editor.dispatchEvent(newOpenEvent(doc, 'test.xml'));
+    await editor.updateComplete;
+
+    const plugin = editor.shadowRoot?.querySelector('*[docname="test.xml"]');
+    expect(plugin).to.have.property('editCount', 0);
+  });
+
+  it('updated passed editCount property on edit events', async () => {
+    editor.dispatchEvent(newOpenEvent(doc, 'test.xml'));
+    await editor.updateComplete;
+
+    editor.dispatchEvent(
+      newEditEvent({
+        element: doc.querySelector('testdoc')!,
+        attributes: { name: 'someName' },
+      })
+    );
+    await editor.updateComplete;
+
+    const plugin = editor.shadowRoot?.querySelector('*[docname="test.xml"]');
+    expect(plugin).to.have.property('editCount', 1);
+  });
+});

--- a/open-scd.ts
+++ b/open-scd.ts
@@ -276,7 +276,7 @@ export class OpenSCD extends Plugging(Editing(LitElement)) {
                 this.docName || nothing
               }" .doc=${this.doc} locale="${this.locale}" .docs=${
                 this.docs
-              }></${unsafeStatic(this.editor)}>`
+              } .editCount=${this.editCount}></${unsafeStatic(this.editor)}>`
             : nothing}
         </mwc-top-app-bar-fixed>
       </mwc-drawer>
@@ -307,7 +307,9 @@ export class OpenSCD extends Plugging(Editing(LitElement)) {
               this.docName
             }" .doc=${this.doc} locale="${this.locale}" .docs=${
               this.docs
-            }></${unsafeStatic(pluginTag(plugin.src))}>`
+            } .editCount=${this.editCount}></${unsafeStatic(
+              pluginTag(plugin.src)
+            )}>`
         )}
       </aside>`;
   }


### PR DESCRIPTION
The property next is changed by open-scd on every change of the XMLDocument and as editCount can therefore be used by both editor and menu type plugins to trigger UI updates.


Closes #84 