### PR TITLE
Bootstrap

### DIFF
--- a/bootstrap.ts
+++ b/bootstrap.ts
@@ -1,0 +1,7 @@
+import { OpenSCD } from './open-scd.js';
+
+type ObjectType<T extends OpenSCD> = { new (): T };
+
+export const bootstrap = (entrypoint: ObjectType<OpenSCD>) => {
+  window.customElements.define('open-scd', entrypoint);
+};

--- a/demo/index.html
+++ b/demo/index.html
@@ -4,7 +4,7 @@
 <open-scd plugins='{"menu": [{"name": "Add plugins...", "translations": {"de": "Erweitern..."}, "icon": "extension", "active": true, "src": "/demo/AddPlugins.js"}, {"name": "Open File", "translations": {"de": "Datei öffnen"}, "icon": "folder_open", "active": true, "src": "https://openscd.github.io/oscd-open/oscd-open.js"}, {"name": "Save File", "translations": {"de": "Datei öffnen"}, "icon": "save", "active": true, "src": "https://openscd.github.io/oscd-save/oscd-save.js"}]}'></open-scd>
 
 <script type="module">
-import '../dist/open-scd.js';
+import '../dist/main.js';
 
 const editor = document.querySelector('open-scd');
 const params = (new URL(document.location)).searchParams;

--- a/main.ts
+++ b/main.ts
@@ -1,0 +1,4 @@
+import { bootstrap } from './bootstrap.js';
+import { OpenSCD } from './open-scd.js';
+
+bootstrap(OpenSCD);

--- a/mixins/Configurating.spec.ts
+++ b/mixins/Configurating.spec.ts
@@ -1,0 +1,39 @@
+import { expect, fixture } from '@open-wc/testing';
+
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+import { Configurating } from './Configurating.js';
+
+namespace util {
+  @customElement('configurating-element')
+  export class ConfiguratingElement extends Configurating(LitElement) {}
+}
+
+describe('Configurating Element', () => {
+  let editor: util.ConfiguratingElement;
+
+  beforeEach(async () => {
+    editor = <util.ConfiguratingElement>(
+      await fixture(html`<configurating-element></configurating-element>`)
+    );
+  });
+
+  it('Sets no configuration', () => {
+    expect(editor).property('configuration').to.be.empty;
+    expect(editor.configuration).to.be.empty;
+  });
+
+  it('Sets a configuration with Dev environment', () => {
+    editor.configuration = {
+      environment: 'dev',
+    };
+
+    expect(editor)
+      .property('configuration')
+      .property('environment')
+      .to.equal('dev');
+
+    expect(editor.configurationItem('environment')).to.equal('dev');
+  });
+});

--- a/mixins/Configurating.ts
+++ b/mixins/Configurating.ts
@@ -1,0 +1,33 @@
+import { property } from 'lit/decorators.js';
+
+import { LitElementConstructor } from '../foundation.js';
+
+type ConfigurationItem = string | number | boolean | Object;
+
+interface Configuration {
+  [key: string]: ConfigurationItem;
+}
+
+/** A mixin for having a configuration on Open-SCD */
+export function Configurating<TBase extends LitElementConstructor>(
+  Base: TBase
+) {
+  class ConfiguratingElement extends Base {
+    #configuration: Configuration = {};
+
+    @property({ type: Object })
+    get configuration(): Configuration {
+      return this.#configuration;
+    }
+
+    set configuration(value: Configuration) {
+      this.#configuration = value;
+    }
+
+    configurationItem(key: string): ConfigurationItem | undefined {
+      return this.#configuration[key];
+    }
+  }
+
+  return ConfiguratingElement;
+}

--- a/open-scd.ts
+++ b/open-scd.ts
@@ -22,6 +22,7 @@ import { isComplex, isInsert, isRemove, isUpdate } from './foundation.js';
 
 import { Editing, LogEntry } from './mixins/Editing.js';
 import { Plugging, pluginTag } from './mixins/Plugging.js';
+import { Configurating } from './mixins/Configurating.js';
 
 type Control = {
   icon: string;
@@ -79,7 +80,7 @@ function renderMenuItem(control: Control): TemplateResult {
 
 @customElement('open-scd')
 @localized()
-export class OpenSCD extends Plugging(Editing(LitElement)) {
+export class OpenSCD extends Plugging(Editing(Configurating(LitElement))) {
   @query('#log')
   logUI!: Dialog;
 


### PR DESCRIPTION
Adding a main.ts and bootstrap.ts forces that the entrypoint will always extend from the OpenSCD (you can create your own extension with mixins).

the entrypoint webcomponent will always have the same tag, so plugins / components can use the querySelector