### PR TITLE
fix: Removed `npm run deploy` from  release-please.yml

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -26,5 +26,3 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
         if: ${{ steps.release.outputs.release_created }}
-      - run: npm run deploy
-        if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
removed npm run deploy from release-please GH action. This repo is already being deployed to GH pages by the deploy.yml GH action.